### PR TITLE
Update AMM/project/moondao splits

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
+            .git
             node_modules
             lib
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,16 @@ jobs:
     name: Foundry project
     runs-on: ubuntu-latest
     steps:
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            node_modules
+            lib
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+
       - uses: actions/checkout@v3
         with:
           submodules: recursive

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,10 +35,16 @@ jobs:
           anvil --fork-url https://1.rpc.thirdweb.com/${{ secrets.THIRDWEB_CLIENT_ID }} &
         id: local-chain
 
+      - name: Install forge dependencies
+        run: |
+          bash install.sh
+        id: install-forge-dependencies
+
       - name: Install npm dependencies
         run: |
           npm install --legacy-peer-deps
-        id: install-dependencies
+        id: install-npm-dependencies
+
 
       - name: Run Forge build
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Local Chain with Anvil
         run: |
-          anvil --fork-url https://1.rpc.thirdweb.com/${{ secrets.THIRDWEB_CLIENT_ID }} &
+          anvil --fork-url https://11155111.rpc.thirdweb.com/${{ secrets.THIRDWEB_CLIENT_ID }} &
         id: local-chain
 
       - name: Install forge dependencies

--- a/foundry.toml
+++ b/foundry.toml
@@ -2,6 +2,7 @@
 src = 'src'
 out = 'out'
 libs = ['lib']
+evm_version = "cancun"
 
 [rpc_endpoints]
 sepolia = "${SEPOLIA_RPC_URL}"

--- a/install.sh
+++ b/install.sh
@@ -1,2 +1,2 @@
-forge install uniswap/v4-core --no-commit
-forge install uniswap/v4-periphery --no-commit
+forge install uniswap/v4-core
+forge install uniswap/v4-periphery

--- a/install.sh
+++ b/install.sh
@@ -1,2 +1,2 @@
-forge install uniswap/v4-core
-forge install uniswap/v4-periphery
+forge install uniswap/v4-core@main
+forge install uniswap/v4-periphery@main

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,2 @@
+forge install uniswap/v4-core --no-commit
+forge install uniswap/v4-periphery --no-commit

--- a/remappings.txt
+++ b/remappings.txt
@@ -13,3 +13,5 @@ solidity-bytes-utils/=node_modules/solidity-bytes-utils/
 solady/=lib/solady/src/
 @nana-core=lib/nana-core/src/
 @uniswap/=lib/
+v4-core/=lib/v4-core/
+v4-periphery/=lib/v4-periphery/

--- a/src/LaunchPadApprovalHook.sol
+++ b/src/LaunchPadApprovalHook.sol
@@ -31,7 +31,7 @@ contract LaunchPadApprovalHook is IJBRulesetApprovalHook {
 
     function approvalStatusOf(
         uint256 projectId,
-        uint256 /* rulesetId */,
+        uint256,
         uint256 start
     ) external view override returns (JBApprovalStatus) {
         uint256 currentFunding = _totalFunding(terminal, projectId);

--- a/src/LaunchPadApprovalHook.sol
+++ b/src/LaunchPadApprovalHook.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/interfaces/IERC165.sol";
+import "@nana-core/interfaces/IJBRulesetApprovalHook.sol";
+import "@nana-core/interfaces/IJBTerminalStore.sol";
+import "@nana-core/libraries/JBConstants.sol";
+
+contract LaunchPadApprovalHook is IJBRulesetApprovalHook {
+    uint256 public immutable fundingGoal;
+    uint256 public immutable deadline; // how long after start we wait
+    IJBTerminalStore public immutable jbTerminalStore;
+    address public immutable terminal;
+
+    /// @param _jbTerminalStoreAddress The Juicebox terminal store
+    /// @param _terminal The specific terminal to pull balances from
+    /// @param _fundingGoal Minimum amount of native tokens to allow approval
+    /// @param _deadline Time window (in seconds) after `start` before auto-approval
+    constructor(
+        uint256 _fundingGoal,
+        uint256 _deadline,
+        address _jbTerminalStoreAddress,
+        address _terminal
+    ) {
+        fundingGoal = _fundingGoal;
+        deadline = _deadline;
+        jbTerminalStore = IJBTerminalStore(_jbTerminalStoreAddress);
+        terminal = _terminal;
+    }
+
+    /// @notice How long after the ruleset’s `start` we’ll wait before approving
+    function DURATION() external view override returns (uint256) {
+        return 0;
+    }
+
+    /// @notice Called by the Juicebox contracts to see if the next ruleset gets the green light
+    /// @param projectId The project whose queue is being advanced
+    /// @param start The timestamp when that ruleset would begin
+    function approvalStatusOf(
+        uint256 projectId,
+        uint256 /* rulesetId */,
+        uint256 start
+    ) external view override returns (JBApprovalStatus) {
+        uint256 currentFunding = _totalFunding(terminal, projectId);
+        if (currentFunding >= fundingGoal && block.timestamp >= deadline) {
+            return JBApprovalStatus.Approved;
+        } else {
+            return JBApprovalStatus.Failed;
+        }
+    }
+
+    /// @dev Juicebox and ERC165 interface support
+    function supportsInterface(bytes4 interfaceId)
+        external
+        pure
+        override
+        returns (bool)
+    {
+        return
+            interfaceId == type(IJBRulesetApprovalHook).interfaceId ||
+            interfaceId == type(IERC165).interfaceId;
+    }
+
+    /// @dev Pulls the project’s balance from the Juicebox terminal store
+    function _totalFunding(address _terminal, uint256 projectId)
+        internal
+        view
+        returns (uint256)
+    {
+        return jbTerminalStore.balanceOf(
+            _terminal,
+            projectId,
+            JBConstants.NATIVE_TOKEN
+        );
+    }
+}
+

--- a/src/LaunchPadApprovalHook.sol
+++ b/src/LaunchPadApprovalHook.sol
@@ -6,16 +6,13 @@ import "@nana-core/interfaces/IJBRulesetApprovalHook.sol";
 import "@nana-core/interfaces/IJBTerminalStore.sol";
 import "@nana-core/libraries/JBConstants.sol";
 
+// Hook to enable payouts after a funding goal is reached and a deadline is passed.
 contract LaunchPadApprovalHook is IJBRulesetApprovalHook {
     uint256 public immutable fundingGoal;
     uint256 public immutable deadline; // how long after start we wait
     IJBTerminalStore public immutable jbTerminalStore;
     address public immutable terminal;
 
-    /// @param _jbTerminalStoreAddress The Juicebox terminal store
-    /// @param _terminal The specific terminal to pull balances from
-    /// @param _fundingGoal Minimum amount of native tokens to allow approval
-    /// @param _deadline Time window (in seconds) after `start` before auto-approval
     constructor(
         uint256 _fundingGoal,
         uint256 _deadline,
@@ -28,14 +25,10 @@ contract LaunchPadApprovalHook is IJBRulesetApprovalHook {
         terminal = _terminal;
     }
 
-    /// @notice How long after the ruleset’s `start` we’ll wait before approving
     function DURATION() external view override returns (uint256) {
         return 0;
     }
 
-    /// @notice Called by the Juicebox contracts to see if the next ruleset gets the green light
-    /// @param projectId The project whose queue is being advanced
-    /// @param start The timestamp when that ruleset would begin
     function approvalStatusOf(
         uint256 projectId,
         uint256 /* rulesetId */,
@@ -49,7 +42,6 @@ contract LaunchPadApprovalHook is IJBRulesetApprovalHook {
         }
     }
 
-    /// @dev Juicebox and ERC165 interface support
     function supportsInterface(bytes4 interfaceId)
         external
         pure
@@ -61,7 +53,6 @@ contract LaunchPadApprovalHook is IJBRulesetApprovalHook {
             interfaceId == type(IERC165).interfaceId;
     }
 
-    /// @dev Pulls the project’s balance from the Juicebox terminal store
     function _totalFunding(address _terminal, uint256 projectId)
         internal
         view
@@ -74,4 +65,3 @@ contract LaunchPadApprovalHook is IJBRulesetApprovalHook {
         );
     }
 }
-

--- a/src/LaunchPadPayHook.sol
+++ b/src/LaunchPadPayHook.sol
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { console2 } from "forge-std/Test.sol"; // remove before deploy
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
-
 import {JBPayHookSpecification} from "@nana-core/structs/JBPayHookSpecification.sol";
 import {IJBRulesets} from "@nana-core/interfaces/IJBRulesets.sol";
 import {JBBeforePayRecordedContext} from "@nana-core/structs/JBBeforePayRecordedContext.sol";

--- a/src/LaunchPadPayHook.sol
+++ b/src/LaunchPadPayHook.sol
@@ -12,9 +12,9 @@ import {IJBRulesetDataHook} from "@nana-core/interfaces/IJBRulesetDataHook.sol";
 import { JBConstants } from "@nana-core/libraries/JBConstants.sol";
 
 
-// LaunchPadPayHook implements the common logic:
-//   • Storing minFundingRequired, fundingGoal and deadline.
-//   • Holding references to the IJBTerminalStore contract.
+// LaunchPadPayHook
+//   • Stores minFundingRequired, fundingGoal and deadline.
+//   • Holdes references to the IJBTerminalStore contract.
 //   • A helper function (_totalFunding) to read total funding.
 //   • An Ownable toggle (setFundingTurnedOff) for the fundingTurnedOff flag.
 //   • The beforePayRecordedWith function manipulates the weight to change number

--- a/src/MissionCreator.sol
+++ b/src/MissionCreator.sol
@@ -118,7 +118,7 @@ contract MissionCreator is Ownable, IERC721Receiver {
                 dataHook: address(launchPadPayHook),
                 metadata: 0 // No metadata is attached to this ruleset.
             }),
-            splitGroups: new JBSplitGroup[](3), // Initialize as dynamic array
+            splitGroups: new JBSplitGroup[](2), // Initialize as dynamic array
             fundAccessLimitGroups: new JBFundAccessLimitGroup[](1) // Initialize as dynamic array
         });
         //TODO: Configure split groups
@@ -132,7 +132,7 @@ contract MissionCreator is Ownable, IERC721Receiver {
             projectId: 0, // Not used.
             preferAddToBalance: false, // Not used, since projectId is 0.
             beneficiary: moonDAOTreasuryPayable, // MoonDAO treasury
-            lockedUntil: type(uint48).max,
+            lockedUntil: type(uint48).max, // Use max value for lock, ~8,000 years. Project owner won't be able to change the split until the 11th millennium.
             hook: IJBSplitHook(address(0)) // Not used.
         });
         rulesetConfigurations[0].splitGroups[0].splits[2] = JBSplit({
@@ -140,7 +140,7 @@ contract MissionCreator is Ownable, IERC721Receiver {
             projectId: 0, // Not used.
             preferAddToBalance: false, // Not used, since projectId is 0.
             beneficiary: toPayable, // Team multisig
-            lockedUntil: type(uint48).max,
+            lockedUntil: type(uint48).max, // Use max value for lock, ~8,000 years. Project owner won't be able to change the split until the 11th millennium.
             hook: IJBSplitHook(address(0)) // Not used.
         });
         rulesetConfigurations[0].splitGroups[1] = JBSplitGroup({
@@ -154,7 +154,7 @@ contract MissionCreator is Ownable, IERC721Receiver {
             projectId: 0, // Not used.
             preferAddToBalance: false, // Not used, since projectId is 0.
             beneficiary: payable(address(moonDAOVesting)), // The beneficiary of the split.
-            lockedUntil: type(uint48).max,
+            lockedUntil: type(uint48).max, // Use max value for lock, ~8,000 years. Project owner won't be able to change the split until the 11th millennium.
             hook: IJBSplitHook(address(0)) // Not used.
         });
         // project token split
@@ -163,7 +163,7 @@ contract MissionCreator is Ownable, IERC721Receiver {
             projectId: 0, // The projectId of the project to send the split to.
             preferAddToBalance: false, // The payment will go to the `pay` function of the project's primary terminal, not the `addToBalanceOf` function.
             beneficiary: payable(address(teamVesting)), // The beneficiary of the payment made to the project's primary terminal. This is the address that will receive the project's tokens issued from the payment.
-            lockedUntil: type(uint48).max,
+            lockedUntil: type(uint48).max, // Use max value for lock, ~8,000 years. Project owner won't be able to change the split until the 11th millennium.
             hook: IJBSplitHook(address(0)) // Not used.
         });
         // amm token split

--- a/src/MissionCreator.sol
+++ b/src/MissionCreator.sol
@@ -15,11 +15,8 @@ import {JBRulesetMetadata} from "@nana-core/structs/JBRulesetMetadata.sol";
 import {JBSplitGroup} from "@nana-core/structs/JBSplitGroup.sol";
 import {JBSplit} from "@nana-core/structs/JBSplit.sol";
 import {JBFundAccessLimitGroup} from "@nana-core/structs/JBFundAccessLimitGroup.sol";
-import {JBCurrencyAmount} from "@nana-core/structs/JBCurrencyAmount.sol";
 import {JBAccountingContext} from "@nana-core/structs/JBAccountingContext.sol";
 import {JBTerminalConfig} from "@nana-core/structs/JBTerminalConfig.sol";
-import {IJBMultiTerminal} from "@nana-core/interfaces/IJBMultiTerminal.sol";
-import {IJBRulesets} from "@nana-core/interfaces/IJBRulesets.sol";
 import {IJBRulesetApprovalHook} from "@nana-core/interfaces/IJBRulesetApprovalHook.sol";
 import {IJBSplitHook} from "@nana-core/interfaces/IJBSplitHook.sol";
 import {IJBTerminal} from "@nana-core/interfaces/IJBTerminal.sol";
@@ -121,29 +118,29 @@ contract MissionCreator is Ownable, IERC721Receiver {
                 dataHook: address(launchPadPayHook),
                 metadata: 0 // No metadata is attached to this ruleset.
             }),
-            splitGroups: new JBSplitGroup[](2), // Initialize as dynamic array
+            splitGroups: new JBSplitGroup[](3), // Initialize as dynamic array
             fundAccessLimitGroups: new JBFundAccessLimitGroup[](1) // Initialize as dynamic array
         });
         //TODO: Configure split groups
         rulesetConfigurations[0].splitGroups[0] = JBSplitGroup({
             groupId: 0xEEEe, // This is the group ID of splits for ETH payouts. Ensure this is a uint256
             // Any leftover split percent amount after all with the group are taken into account will go to the project owner.
-            splits: new JBSplit[](2) // Initialize as dynamic array
+            splits: new JBSplit[](3) // Initialize as dynamic array
         });
         rulesetConfigurations[0].splitGroups[0].splits[0] = JBSplit({
-            percent: 100_000_000, // 10%, out of 1_000_000_000
+            percent: 179_487_180, // works out to 17.5% after 2.5% fee. 10% for liquidity, 7.5% for moondao fee (out of 1_000_000_000)
             projectId: 0, // Not used.
             preferAddToBalance: false, // Not used, since projectId is 0.
             beneficiary: moonDAOTreasuryPayable, // MoonDAO treasury
-            lockedUntil: type(uint48).max, // Use max value for lock, ~8,000 years. Project owner won't be able to change the split until the 11th millennium.
+            lockedUntil: type(uint48).max,
             hook: IJBSplitHook(address(0)) // Not used.
         });
-        rulesetConfigurations[0].splitGroups[0].splits[1] = JBSplit({
-            percent: 900_000_000, // 90%, out of 1_000_000_000
+        rulesetConfigurations[0].splitGroups[0].splits[2] = JBSplit({
+            percent: 820_512_820, // works out to 80% after 2.5% fee (out of 1_000_000_000)
             projectId: 0, // Not used.
             preferAddToBalance: false, // Not used, since projectId is 0.
             beneficiary: toPayable, // Team multisig
-            lockedUntil: type(uint48).max, // Use max value for lock, ~8,000 years. Project owner won't be able to change the split until the 11th millennium.
+            lockedUntil: type(uint48).max,
             hook: IJBSplitHook(address(0)) // Not used.
         });
         rulesetConfigurations[0].splitGroups[1] = JBSplitGroup({
@@ -157,7 +154,7 @@ contract MissionCreator is Ownable, IERC721Receiver {
             projectId: 0, // Not used.
             preferAddToBalance: false, // Not used, since projectId is 0.
             beneficiary: payable(address(moonDAOVesting)), // The beneficiary of the split.
-            lockedUntil: type(uint48).max, // Use max value for lock, ~8,000 years. Project owner won't be able to change the split until the 11th millennium.
+            lockedUntil: type(uint48).max,
             hook: IJBSplitHook(address(0)) // Not used.
         });
         // project token split
@@ -166,7 +163,7 @@ contract MissionCreator is Ownable, IERC721Receiver {
             projectId: 0, // The projectId of the project to send the split to.
             preferAddToBalance: false, // The payment will go to the `pay` function of the project's primary terminal, not the `addToBalanceOf` function.
             beneficiary: payable(address(teamVesting)), // The beneficiary of the payment made to the project's primary terminal. This is the address that will receive the project's tokens issued from the payment.
-            lockedUntil: type(uint48).max, // Use max value for lock, ~8,000 years. Project owner won't be able to change the split until the 11th millennium.
+            lockedUntil: type(uint48).max,
             hook: IJBSplitHook(address(0)) // Not used.
         });
         // amm token split
@@ -175,7 +172,7 @@ contract MissionCreator is Ownable, IERC721Receiver {
             projectId: 0, // Not used.
             preferAddToBalance: false, // Not used, since projectId is 0.
             // FIXME set up amm
-            beneficiary: payable(address(0)), // The beneficiary of the split. This is the address that will receive the project's tokens issued from the payment.
+            beneficiary: moonDAOTreasuryPayable, // The beneficiary of the split. This is the address that will receive the project's tokens issued from the payment.
             lockedUntil: type(uint48).max, // Use max value for lock, ~8,000 years. Project owner won't be able to change the split until the 11th millennium.
             hook: IJBSplitHook(address(0)) // Not used.
         });

--- a/src/MissionCreator.sol
+++ b/src/MissionCreator.sol
@@ -172,7 +172,7 @@ contract MissionCreator is Ownable, IERC721Receiver {
             projectId: 0, // Not used.
             preferAddToBalance: false, // Not used, since projectId is 0.
             // FIXME set up amm
-            beneficiary: moonDAOTreasuryPayable, // The beneficiary of the split. This is the address that will receive the project's tokens issued from the payment.
+            beneficiary: payable(address(0)), // The beneficiary of the split. This is the address that will receive the project's tokens issued from the payment.
             lockedUntil: type(uint48).max, // Use max value for lock, ~8,000 years. Project owner won't be able to change the split until the 11th millennium.
             hook: IJBSplitHook(address(0)) // Not used.
         });

--- a/src/MissionCreator.sol
+++ b/src/MissionCreator.sol
@@ -168,12 +168,12 @@ contract MissionCreator is Ownable, IERC721Receiver {
 
         JBCurrencyAmount[] memory surplusAllowances = new JBCurrencyAmount[](1);
         surplusAllowances[0] = JBCurrencyAmount({
-            amount: uint224(128_000_000 * 10 ** 18), // 128 million ETH
+            amount: uint224(128_000_000 * 10 ** 18), // 128 million ETH, functionally unlimited
             currency: uint32(uint160(JBConstants.NATIVE_TOKEN))
         });
         JBCurrencyAmount[] memory payoutLimits = new JBCurrencyAmount[](1);
         payoutLimits[0] = JBCurrencyAmount({
-            amount: uint224(128_000_000 * 10 ** 18), // 128 million ETH
+            amount: uint224(128_000_000 * 10 ** 18), // 128 million ETH, functionally unlimited
             currency: uint32(uint160(JBConstants.NATIVE_TOKEN))
         });
         rulesetConfigurations[0].fundAccessLimitGroups[0] = JBFundAccessLimitGroup({

--- a/src/MissionCreator.sol
+++ b/src/MissionCreator.sol
@@ -12,6 +12,7 @@ import {IJBController} from "@nana-core/interfaces/IJBController.sol";
 import {IJBProjects} from "@nana-core/interfaces/IJBProjects.sol";
 import {JBRulesetConfig} from "@nana-core/structs/JBRulesetConfig.sol";
 import {LaunchPadPayHook} from "./LaunchPadPayHook.sol";
+import {LaunchPadApprovalHook} from "./LaunchPadApprovalHook.sol";
 import {JBRulesetMetadata} from "@nana-core/structs/JBRulesetMetadata.sol";
 import {JBSplitGroup} from "@nana-core/structs/JBSplitGroup.sol";
 import {JBSplit} from "@nana-core/structs/JBSplit.sol";
@@ -96,8 +97,40 @@ contract MissionCreator is Ownable, IERC721Receiver {
             deadline = block.timestamp + 28 days;
         }
         LaunchPadPayHook launchPadPayHook = new LaunchPadPayHook(fundingGoal, deadline, jbTerminalStoreAddress, jbRulesetsAddress, to);
-        JBRulesetConfig[] memory rulesetConfigurations = new JBRulesetConfig[](1);
+        LaunchPadApprovalHook launchPadApprovalHook = new LaunchPadApprovalHook(fundingGoal, deadline, jbTerminalStoreAddress, address(terminal));
+        JBRulesetConfig[] memory rulesetConfigurations = new JBRulesetConfig[](2);
+        JBSplitGroup[] memory splitGroups = new JBSplitGroup[](2);
         rulesetConfigurations[0] = JBRulesetConfig({
+            mustStartAtOrAfter: 0, // A 0 timestamp means the ruleset will start right away, or as soon as possible if there are already other rulesets queued.
+            duration: 0, // A duration of 0 means the ruleset will last indefinitely until the next ruleset is queued. Any non-zero value would be the number of seconds this ruleset will last before the next ruleset is queued. If no new rulesets are queued, this ruleset will cycle over to another period with the same duration.
+            weight: 2_000_000_000_000_000_000_000, // Standard rate is 2,000 tokens issued per unit of `baseCurrency` set below, 1,000 going to the funder and 1,000 going to the project. Note that this will be modified by the payhook based on current amount of funds raised, min funding required, and funding goal.
+            weightCutPercent: 0, // 0% weight cut. If the `duration` property above is set to a non-zero value, the `weightCutPercent` property will be used to determine how much of the weight is cut from this ruleset to the next cycle.
+            approvalHook: IJBRulesetApprovalHook(address(launchPadApprovalHook)), // No approval hook contract is attached to this ruleset, meaning new rulesets can be queued at any time and will take effect as soon as possible given the current ruleset's `duration`.
+            metadata: JBRulesetMetadata({
+                reservedPercent: 5_000, // 50% of tokens are reserved, to be split according to the `splitGroups` property below.
+                cashOutTaxRate: 0, // 0% tax on cashouts.
+                baseCurrency: 61166, // ETH currency. Together with the `weight` property, this determines how many tokens are issued per ETH received. If the project receives a different token, say USDC, a price feed will determine the ETH value of the USDC at the time of the transaction in order to determine how many tokens are issued per USDC received.
+                pausePay: false, // Payouts are not paused.
+                pauseCreditTransfers: false, // Credit transfers are not paused.
+                allowOwnerMinting: false, // The project owner cannot mint new tokens.
+                allowSetCustomToken: false, // The project cannot set a custom token.
+                allowTerminalMigration: false, // The project cannot move funds between terminals.
+                allowSetTerminals: false, // The project cannot set new terminals.
+                allowSetController: false, // The project cannot set a new controller.
+                allowAddAccountingContext: false, // The project cannot add new accounting contexts to its terminals.
+                allowAddPriceFeed: false, // The project cannot add new price feeds.
+                ownerMustSendPayouts: false, // Anyone can send this project's payouts to the splits specified in the `splitGroups` property below.
+                holdFees: false, // Fees are not held.
+                useTotalSurplusForCashOuts: false, // Cash outs are made from each terminal independently.
+                useDataHookForPay: true,
+                useDataHookForCashOut: true,
+                dataHook: address(launchPadPayHook),
+                metadata: 0 // No metadata is attached to this ruleset.
+            }),
+            splitGroups: splitGroups, // Initialize as dynamic array
+            fundAccessLimitGroups: new JBFundAccessLimitGroup[](1) // Initialize as dynamic array
+        });
+        rulesetConfigurations[1] = JBRulesetConfig({
             mustStartAtOrAfter: 0, // A 0 timestamp means the ruleset will start right away, or as soon as possible if there are already other rulesets queued.
             duration: 0, // A duration of 0 means the ruleset will last indefinitely until the next ruleset is queued. Any non-zero value would be the number of seconds this ruleset will last before the next ruleset is queued. If no new rulesets are queued, this ruleset will cycle over to another period with the same duration.
             weight: 2_000_000_000_000_000_000_000, // Standard rate is 2,000 tokens issued per unit of `baseCurrency` set below, 1,000 going to the funder and 1,000 going to the project. Note that this will be modified by the payhook based on current amount of funds raised, min funding required, and funding goal.
@@ -124,10 +157,15 @@ contract MissionCreator is Ownable, IERC721Receiver {
                 dataHook: address(launchPadPayHook),
                 metadata: 0 // No metadata is attached to this ruleset.
             }),
-            splitGroups: new JBSplitGroup[](2), // Initialize as dynamic array
+            splitGroups: splitGroups, // Initialize as dynamic array
             fundAccessLimitGroups: new JBFundAccessLimitGroup[](1) // Initialize as dynamic array
         });
 
+        JBCurrencyAmount[] memory surplusAllowances = new JBCurrencyAmount[](1);
+        surplusAllowances[0] = JBCurrencyAmount({
+            amount: uint224(128_000_000 * 10 ** 18), // 128 million ETH
+            currency: uint32(uint160(JBConstants.NATIVE_TOKEN))
+        });
         JBCurrencyAmount[] memory payoutLimits = new JBCurrencyAmount[](1);
         payoutLimits[0] = JBCurrencyAmount({
             amount: uint224(128_000_000 * 10 ** 18), // 128 million ETH
@@ -136,16 +174,22 @@ contract MissionCreator is Ownable, IERC721Receiver {
         rulesetConfigurations[0].fundAccessLimitGroups[0] = JBFundAccessLimitGroup({
             terminal: address(terminal),
             token: JBConstants.NATIVE_TOKEN,
+            payoutLimits: new JBCurrencyAmount[](0),
+            surplusAllowances: surplusAllowances
+        });
+        rulesetConfigurations[1].fundAccessLimitGroups[0] = JBFundAccessLimitGroup({
+            terminal: address(terminal),
+            token: JBConstants.NATIVE_TOKEN,
             payoutLimits: payoutLimits,
             surplusAllowances: new JBCurrencyAmount[](0)
         });
         //TODO: Configure split groups
-        rulesetConfigurations[0].splitGroups[0] = JBSplitGroup({
+        splitGroups[0] = JBSplitGroup({
             groupId: 0xEEEe, // This is the group ID of splits for ETH payouts. Ensure this is a uint256
             // Any leftover split percent amount after all with the group are taken into account will go to the project owner.
             splits: new JBSplit[](3) // Initialize as dynamic array
         });
-        rulesetConfigurations[0].splitGroups[0].splits[0] = JBSplit({
+        splitGroups[0].splits[0] = JBSplit({
             percent: 76_923_076, // works out to 7.5% after 2.5% jb fee.
             projectId: 0, // Not used.
             preferAddToBalance: false, // Not used, since projectId is 0.
@@ -153,7 +197,7 @@ contract MissionCreator is Ownable, IERC721Receiver {
             lockedUntil: type(uint48).max, // Use max value for lock, ~8,000 years. Project owner won't be able to change the split until the 11th millennium.
             hook: IJBSplitHook(address(0)) // Not used.
         });
-        rulesetConfigurations[0].splitGroups[0].splits[1] = JBSplit({
+        splitGroups[0].splits[1] = JBSplit({
             percent: 102_564_102, // works out to 10% after 2.5% jb fee.
             projectId: 0, // Not used.
             preferAddToBalance: false, // Not used, since projectId is 0.
@@ -161,7 +205,7 @@ contract MissionCreator is Ownable, IERC721Receiver {
             lockedUntil: type(uint48).max, // Use max value for lock, ~8,000 years. Project owner won't be able to change the split until the 11th millennium.
             hook: IJBSplitHook(address(0)) // Not used.
         });
-        rulesetConfigurations[0].splitGroups[0].splits[2] = JBSplit({
+        splitGroups[0].splits[2] = JBSplit({
             percent: 820_512_820, // works out to 80% after 2.5% jb fee.
             projectId: 0, // Not used.
             preferAddToBalance: false, // Not used, since projectId is 0.
@@ -169,14 +213,14 @@ contract MissionCreator is Ownable, IERC721Receiver {
             lockedUntil: type(uint48).max, // Use max value for lock, ~8,000 years. Project owner won't be able to change the split until the 11th millennium.
             hook: IJBSplitHook(address(0)) // Not used.
         });
-        rulesetConfigurations[0].splitGroups[1] = JBSplitGroup({
+        splitGroups[1] = JBSplitGroup({
             groupId: 1, // This is the group ID of splits for reserved token distribution.
             // Any leftover split percent amount after all with the group are taken into account will go to the project owner.
             splits: new JBSplit[](3) // Initialize as dynamic array
         });
         // moondao token split
-        rulesetConfigurations[0].splitGroups[1].splits[0] = JBSplit({
-            percent: 200_000_000, // 20% out of 1_000_000_000, of the 50% reserved tokens = 10% of total tokens
+        splitGroups[1].splits[0] = JBSplit({
+            percent: 300_000_000, // 30% out of 1_000_000_000, of the 50% reserved tokens = 15% of total tokens
             projectId: 0, // Not used.
             preferAddToBalance: false, // Not used, since projectId is 0.
             beneficiary: payable(address(moonDAOVesting)), // The beneficiary of the split.
@@ -184,7 +228,7 @@ contract MissionCreator is Ownable, IERC721Receiver {
             hook: IJBSplitHook(address(0)) // Not used.
         });
         // project token split
-        rulesetConfigurations[0].splitGroups[1].splits[1] = JBSplit({
+        splitGroups[1].splits[1] = JBSplit({
             percent: 600_000_000, // 60% out of 1_000_000_000, of the 50% reserved tokens = 30% of total tokens
             projectId: 0, // The projectId of the project to send the split to.
             preferAddToBalance: false, // The payment will go to the `pay` function of the project's primary terminal, not the `addToBalanceOf` function.
@@ -193,8 +237,8 @@ contract MissionCreator is Ownable, IERC721Receiver {
             hook: IJBSplitHook(address(0)) // Not used.
         });
         // amm token split
-        rulesetConfigurations[0].splitGroups[1].splits[2] = JBSplit({
-            percent: 200_000_000, // 20% out of 1_000_000_000, of the 50% reserved tokens = 10% of total tokens
+        splitGroups[1].splits[2] = JBSplit({
+            percent: 100_000_000, // 20% out of 1_000_000_000, of the 50% reserved tokens = 10% of total tokens
             projectId: 0, // Not used.
             preferAddToBalance: false, // Not used, since projectId is 0.
             beneficiary: payable(address(poolDeployer)), // The beneficiary of the split. This is the address that will receive the project's tokens issued from the payment.

--- a/src/MissionCreator.sol
+++ b/src/MissionCreator.sol
@@ -6,6 +6,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import {MissionTable} from "./tables/MissionTable.sol";
 import {Vesting} from "./Vesting.sol";
+import {PoolDeployer} from "./PoolDeployer.sol";
 import {MoonDAOTeam} from "./ERC5643.sol";
 import {IJBController} from "@nana-core/interfaces/IJBController.sol";
 import {IJBProjects} from "@nana-core/interfaces/IJBProjects.sol";
@@ -15,6 +16,8 @@ import {JBRulesetMetadata} from "@nana-core/structs/JBRulesetMetadata.sol";
 import {JBSplitGroup} from "@nana-core/structs/JBSplitGroup.sol";
 import {JBSplit} from "@nana-core/structs/JBSplit.sol";
 import {JBFundAccessLimitGroup} from "@nana-core/structs/JBFundAccessLimitGroup.sol";
+import {JBCurrencyAmount} from "@nana-core/structs/JBCurrencyAmount.sol";
+import {JBConstants} from "@nana-core/libraries/JBConstants.sol";
 import {JBAccountingContext} from "@nana-core/structs/JBAccountingContext.sol";
 import {JBTerminalConfig} from "@nana-core/structs/JBTerminalConfig.sol";
 import {IJBRulesetApprovalHook} from "@nana-core/interfaces/IJBRulesetApprovalHook.sol";
@@ -34,6 +37,7 @@ contract MissionCreator is Ownable, IERC721Receiver {
     mapping(uint256 => address) public missionIdToPayHook;
     mapping(uint256 => address) public missionIdToTeamVesting;
     mapping(uint256 => address) public missionIdToMoonDAOVesting;
+    mapping(uint256 => address) public missionIdToPoolDeployer;
     mapping(uint256 => uint256) public missionIdToFundingGoal;
     mapping(uint256 => address) public missionIdToTerminal;
 
@@ -85,6 +89,8 @@ contract MissionCreator is Ownable, IERC721Receiver {
         IJBTerminal terminal = IJBTerminal(jbMultiTerminalAddress);
         Vesting moonDAOVesting = new Vesting(moonDAOTreasuryPayable);
         Vesting teamVesting = new Vesting(toPayable);
+        PoolDeployer poolDeployer = new PoolDeployer();
+
 
         if (block.chainid != 11155111) {
             deadline = block.timestamp + 28 days;
@@ -121,14 +127,26 @@ contract MissionCreator is Ownable, IERC721Receiver {
             splitGroups: new JBSplitGroup[](2), // Initialize as dynamic array
             fundAccessLimitGroups: new JBFundAccessLimitGroup[](1) // Initialize as dynamic array
         });
+
+        JBCurrencyAmount[] memory payoutLimits = new JBCurrencyAmount[](1);
+        payoutLimits[0] = JBCurrencyAmount({
+            amount: uint224(128_000_000 * 10 ** 18), // 128 million ETH
+            currency: uint32(uint160(JBConstants.NATIVE_TOKEN))
+        });
+        rulesetConfigurations[0].fundAccessLimitGroups[0] = JBFundAccessLimitGroup({
+            terminal: address(terminal),
+            token: JBConstants.NATIVE_TOKEN,
+            payoutLimits: payoutLimits,
+            surplusAllowances: new JBCurrencyAmount[](0)
+        });
         //TODO: Configure split groups
         rulesetConfigurations[0].splitGroups[0] = JBSplitGroup({
             groupId: 0xEEEe, // This is the group ID of splits for ETH payouts. Ensure this is a uint256
             // Any leftover split percent amount after all with the group are taken into account will go to the project owner.
-            splits: new JBSplit[](2) // Initialize as dynamic array
+            splits: new JBSplit[](3) // Initialize as dynamic array
         });
         rulesetConfigurations[0].splitGroups[0].splits[0] = JBSplit({
-            percent: 179_487_180, // works out to 17.5% after 2.5% fee. 10% for liquidity, 7.5% for moondao fee (out of 1_000_000_000)
+            percent: 89_743_590, // works out to 8.75% after 2.5% jb fee.
             projectId: 0, // Not used.
             preferAddToBalance: false, // Not used, since projectId is 0.
             beneficiary: moonDAOTreasuryPayable, // MoonDAO treasury
@@ -136,7 +154,15 @@ contract MissionCreator is Ownable, IERC721Receiver {
             hook: IJBSplitHook(address(0)) // Not used.
         });
         rulesetConfigurations[0].splitGroups[0].splits[1] = JBSplit({
-            percent: 820_512_820, // works out to 80% after 2.5% fee (out of 1_000_000_000)
+            percent: 89_743_590, // works out to 8.75% after 2.5% jb fee.
+            projectId: 0, // Not used.
+            preferAddToBalance: false, // Not used, since projectId is 0.
+            beneficiary: payable(address(poolDeployer)), // MoonDAO treasury
+            lockedUntil: type(uint48).max, // Use max value for lock, ~8,000 years. Project owner won't be able to change the split until the 11th millennium.
+            hook: IJBSplitHook(address(0)) // Not used.
+        });
+        rulesetConfigurations[0].splitGroups[0].splits[2] = JBSplit({
+            percent: 820_512_820, // works out to 80% after 2.5% jb fee.
             projectId: 0, // Not used.
             preferAddToBalance: false, // Not used, since projectId is 0.
             beneficiary: toPayable, // Team multisig
@@ -171,8 +197,7 @@ contract MissionCreator is Ownable, IERC721Receiver {
             percent: 200_000_000, // 20% out of 1_000_000_000, of the 50% reserved tokens = 10% of total tokens
             projectId: 0, // Not used.
             preferAddToBalance: false, // Not used, since projectId is 0.
-            // FIXME set up amm
-            beneficiary: payable(address(0)), // The beneficiary of the split. This is the address that will receive the project's tokens issued from the payment.
+            beneficiary: payable(address(poolDeployer)), // The beneficiary of the split. This is the address that will receive the project's tokens issued from the payment.
             lockedUntil: type(uint48).max, // Use max value for lock, ~8,000 years. Project owner won't be able to change the split until the 11th millennium.
             hook: IJBSplitHook(address(0)) // Not used.
         });
@@ -204,6 +229,8 @@ contract MissionCreator is Ownable, IERC721Receiver {
         }
         moonDAOVesting.setToken(tokenAddress);
         teamVesting.setToken(tokenAddress);
+        poolDeployer.setToken(tokenAddress);
+
 
         jbProjects.safeTransferFrom(address(this), to, projectId);
 
@@ -212,6 +239,7 @@ contract MissionCreator is Ownable, IERC721Receiver {
         missionIdToPayHook[missionId] = address(launchPadPayHook);
         missionIdToTeamVesting[missionId] = address(teamVesting);
         missionIdToMoonDAOVesting[missionId] = address(moonDAOVesting);
+        missionIdToPoolDeployer[missionId] = address(poolDeployer);
         missionIdToFundingGoal[missionId] = fundingGoal;
         missionIdToTerminal[missionId] = address(terminal);
 

--- a/src/MissionCreator.sol
+++ b/src/MissionCreator.sol
@@ -99,9 +99,10 @@ contract MissionCreator is Ownable, IERC721Receiver {
         LaunchPadPayHook launchPadPayHook = new LaunchPadPayHook(fundingGoal, deadline, jbTerminalStoreAddress, jbRulesetsAddress, to);
         LaunchPadApprovalHook launchPadApprovalHook = new LaunchPadApprovalHook(fundingGoal, deadline, jbTerminalStoreAddress, address(terminal));
         // Ruleset 0 is funding/refunds
-        // Ruleset 0 has a cashout hook that will only allow refunds if the deadline has not passed and the funding goal has not been met.
+        // Ruleset 0 has a cashout hook that will only allow refunds if the deadline has passed and the funding goal has not been met.
         // Ruleset 0 has an approval hook that will automatically move to ruleset 1 if the funding goal is met and if the deadline has passed.
         // Ruleset 1 unlocks payouts
+        // Ruleset 0/1 only differ in approval hook and fund access limits.
         JBRulesetConfig[] memory rulesetConfigurations = new JBRulesetConfig[](2);
         JBSplitGroup[] memory splitGroups = new JBSplitGroup[](2);
         rulesetConfigurations[0] = JBRulesetConfig({

--- a/src/MissionCreator.sol
+++ b/src/MissionCreator.sol
@@ -125,7 +125,7 @@ contract MissionCreator is Ownable, IERC721Receiver {
         rulesetConfigurations[0].splitGroups[0] = JBSplitGroup({
             groupId: 0xEEEe, // This is the group ID of splits for ETH payouts. Ensure this is a uint256
             // Any leftover split percent amount after all with the group are taken into account will go to the project owner.
-            splits: new JBSplit[](3) // Initialize as dynamic array
+            splits: new JBSplit[](2) // Initialize as dynamic array
         });
         rulesetConfigurations[0].splitGroups[0].splits[0] = JBSplit({
             percent: 179_487_180, // works out to 17.5% after 2.5% fee. 10% for liquidity, 7.5% for moondao fee (out of 1_000_000_000)
@@ -135,7 +135,7 @@ contract MissionCreator is Ownable, IERC721Receiver {
             lockedUntil: type(uint48).max, // Use max value for lock, ~8,000 years. Project owner won't be able to change the split until the 11th millennium.
             hook: IJBSplitHook(address(0)) // Not used.
         });
-        rulesetConfigurations[0].splitGroups[0].splits[2] = JBSplit({
+        rulesetConfigurations[0].splitGroups[0].splits[1] = JBSplit({
             percent: 820_512_820, // works out to 80% after 2.5% fee (out of 1_000_000_000)
             projectId: 0, // Not used.
             preferAddToBalance: false, // Not used, since projectId is 0.

--- a/src/MissionCreator.sol
+++ b/src/MissionCreator.sol
@@ -146,7 +146,7 @@ contract MissionCreator is Ownable, IERC721Receiver {
             splits: new JBSplit[](3) // Initialize as dynamic array
         });
         rulesetConfigurations[0].splitGroups[0].splits[0] = JBSplit({
-            percent: 89_743_590, // works out to 8.75% after 2.5% jb fee.
+            percent: 76_923_076, // works out to 7.5% after 2.5% jb fee.
             projectId: 0, // Not used.
             preferAddToBalance: false, // Not used, since projectId is 0.
             beneficiary: moonDAOTreasuryPayable, // MoonDAO treasury
@@ -154,7 +154,7 @@ contract MissionCreator is Ownable, IERC721Receiver {
             hook: IJBSplitHook(address(0)) // Not used.
         });
         rulesetConfigurations[0].splitGroups[0].splits[1] = JBSplit({
-            percent: 89_743_590, // works out to 8.75% after 2.5% jb fee.
+            percent: 102_564_102, // works out to 10% after 2.5% jb fee.
             projectId: 0, // Not used.
             preferAddToBalance: false, // Not used, since projectId is 0.
             beneficiary: payable(address(poolDeployer)), // MoonDAO treasury

--- a/src/MissionCreator.sol
+++ b/src/MissionCreator.sol
@@ -98,6 +98,10 @@ contract MissionCreator is Ownable, IERC721Receiver {
         }
         LaunchPadPayHook launchPadPayHook = new LaunchPadPayHook(fundingGoal, deadline, jbTerminalStoreAddress, jbRulesetsAddress, to);
         LaunchPadApprovalHook launchPadApprovalHook = new LaunchPadApprovalHook(fundingGoal, deadline, jbTerminalStoreAddress, address(terminal));
+        // Ruleset 0 is funding/refunds
+        // Ruleset 0 has a cashout hook that will only allow refunds if the deadline has not passed and the funding goal has not been met.
+        // Ruleset 0 has an approval hook that will automatically move to ruleset 1 if the funding goal is met and if the deadline has passed.
+        // Ruleset 1 unlocks payouts
         JBRulesetConfig[] memory rulesetConfigurations = new JBRulesetConfig[](2);
         JBSplitGroup[] memory splitGroups = new JBSplitGroup[](2);
         rulesetConfigurations[0] = JBRulesetConfig({

--- a/src/PoolDeployer.sol
+++ b/src/PoolDeployer.sol
@@ -67,7 +67,6 @@ contract PoolDeployer {
         uint256 amount0 = address(this).balance - 1 wei;
         uint256 amount1 = token.balanceOf(address(this)) - 1 wei;
         require(amount0 > 0 && amount1 > 0, "no funds to deploy");
-        console.log("amount0: %s, amount1: %s", amount0, amount1);
 
         // approvals for PERMIT2 & PositionManager
         token.approve(address(PERMIT2), type(uint256).max);

--- a/src/PoolDeployer.sol
+++ b/src/PoolDeployer.sol
@@ -39,8 +39,8 @@ contract PoolDeployer {
     // use 1000:1 as starting price based on jb price of 0.001 per token
     //uint160 public startingPrice = 2505414483750479251915866636288;
     uint160 startingPrice = 79228162514264337593543950336; // floor(sqrt(1) * 2^96)
-    int24  public tickLower     = -600;
-    int24  public tickUpper     =  600;
+
+    // set tickLower and tickUpper to give liquidity at all prices
 
     constructor() {
         POSITION_MANAGERS[MAINNET] = 0xbD216513d74C8cf14cf4747E6AaA6420FF64ee9e;
@@ -72,6 +72,9 @@ contract PoolDeployer {
         token.approve(address(PERMIT2), type(uint256).max);
         PERMIT2.approve(address(token), address(posm), type(uint160).max, type(uint48).max);
 
+        int24 tickSpacing = 100;
+        int24 tickLower = TickMath.minUsableTick(tickSpacing);
+        int24 tickUpper = TickMath.maxUsableTick(tickSpacing);
         uint128 liquidity = LiquidityAmounts.getLiquidityForAmounts(
             startingPrice,
             TickMath.getSqrtPriceAtTick(tickLower),
@@ -84,7 +87,6 @@ contract PoolDeployer {
         uint256 amount1Max = amount1 + 1 wei;
 
 
-        int24 tickSpacing = 60;
         PoolKey memory poolKey = PoolKey({
             currency0: CurrencyLibrary.ADDRESS_ZERO,
             currency1: Currency.wrap(address(token)),

--- a/src/PoolDeployer.sol
+++ b/src/PoolDeployer.sol
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {PositionManager} from "v4-periphery/src/PositionManager.sol";
+import {IHooks} from "v4-core/src/interfaces/IHooks.sol";
+import {PoolKey} from "v4-core/src/types/PoolKey.sol";
+import {CurrencyLibrary, Currency} from "v4-core/src/types/Currency.sol";
+import {Actions} from "v4-periphery/src/libraries/Actions.sol";
+import {LiquidityAmounts} from "v4-core/test/utils/LiquidityAmounts.sol";
+import {TickMath} from "v4-core/src/libraries/TickMath.sol";
+import {IERC20} from "forge-std/interfaces/IERC20.sol";
+//import {IAllowanceTransfer} from "permit2/src/interfaces/IAllowanceTransfer.sol";
+
+interface IAllowanceTransfer {
+    function approve(
+        address token,
+        address spender,
+        uint160 amount,
+        uint48 expiry
+    ) external;
+}
+
+contract PoolDeployer {
+    using CurrencyLibrary for Currency;
+    IAllowanceTransfer constant PERMIT2 = IAllowanceTransfer(address(0x000000000022D473030F116dDEE9F6B43aC78BA3));
+    mapping(uint256 => address) public POSITION_MANAGERS;
+    uint256 MAINNET = 1;
+    uint256 ARBITRUM = 42161;
+    uint256 BASE = 8453;
+    uint256 ARB_SEP = 421614;
+    uint256 SEP = 11155111;
+
+    PositionManager public posm;
+    IERC20 public token;
+    address public hookAddress = address(0x45A0AA93f6972AA137086002527B2ECc1D1b8844);
+
+    // the startingPrice is expressed as sqrtPriceX96: floor(sqrt(token / token0) * 2^96)
+    // use 1000:1 as starting price based on jb price of 0.001 per token
+    uint160 public startingPrice = 2505414483750479251915866636288;
+    int24  public tickLower     = -600;
+    int24  public tickUpper     =  600;
+
+    constructor() {
+        POSITION_MANAGERS[MAINNET] = 0xbD216513d74C8cf14cf4747E6AaA6420FF64ee9e;
+        POSITION_MANAGERS[ARBITRUM] = 0xd88F38F930b7952f2DB2432Cb002E7abbF3dD869;
+        POSITION_MANAGERS[BASE] = 0x7C5f5A4bBd8fD63184577525326123B519429bDc;
+        POSITION_MANAGERS[ARB_SEP] = 0xAc631556d3d4019C95769033B5E719dD77124BAc;
+        POSITION_MANAGERS[SEP] = 0x429ba70129df741B2Ca2a85BC3A2a3328e5c09b4;
+        posm = PositionManager(payable(POSITION_MANAGERS[block.chainid]));
+    }
+
+    // Allow contract to receive ETH
+    receive() external payable {}
+
+    function setToken(address _token) external {
+        require(address(token) == address(0), "Token already set");
+        token = IERC20(_token);
+    }
+
+    function setHookAddress(address _hookAddress) external {
+        hookAddress = _hookAddress;
+    }
+
+    function createAndAddLiquidity() external {
+        uint256 amount0 = address(this).balance;
+        uint256 amount1 = token.balanceOf(address(this));
+        require(amount0 > 0 && amount1 > 0, "no funds to deploy");
+
+        // approvals for PERMIT2 & PositionManager
+        token.approve(address(PERMIT2), type(uint256).max);
+        PERMIT2.approve(address(token), address(posm), type(uint160).max, type(uint48).max);
+
+        uint128 liquidity = LiquidityAmounts.getLiquidityForAmounts(
+            startingPrice,
+            TickMath.getSqrtPriceAtTick(tickLower),
+            TickMath.getSqrtPriceAtTick(tickUpper),
+            amount0,
+            amount1
+        );
+
+        uint256 amount0Max = amount0;
+        uint256 amount1Max = amount1;
+
+
+        int24 tickSpacing = 60;
+        PoolKey memory poolKey = PoolKey({
+            currency0: CurrencyLibrary.ADDRESS_ZERO,
+            currency1: Currency.wrap(address(token)),
+            fee: 10000, // 1% fee
+            tickSpacing: tickSpacing,
+            hooks: IHooks(hookAddress)
+        });
+
+        (bytes memory actions, bytes[] memory mintParams) = _mintLiquidityParams(
+            poolKey,
+            tickLower,
+            tickUpper,
+            liquidity,
+            amount0Max,
+            amount1Max,
+            hookAddress,
+            ""
+        );
+
+        bytes[] memory params = new bytes[](2);
+        params[0] = abi.encodeWithSelector(posm.initializePool.selector, poolKey, startingPrice, "");
+        params[1] = abi.encodeWithSelector(
+          posm.modifyLiquidities.selector,
+          abi.encode(actions, mintParams),
+          block.timestamp + 60
+        );
+        posm.multicall{value: amount0Max}(params);
+    }
+
+    function _mintLiquidityParams(
+      PoolKey memory poolKey,
+      int24 _tickLower,
+      int24 _tickUpper,
+      uint256 liquidity,
+      uint256 amount0Max,
+      uint256 amount1Max,
+      address recipient,
+      bytes memory hookData
+    ) internal pure returns (bytes memory, bytes[] memory) {
+        bytes memory actions = abi.encodePacked(uint8(Actions.MINT_POSITION), uint8(Actions.SETTLE_PAIR));
+        bytes[] memory params = new bytes[](2);
+        params[0] = abi.encode(poolKey, _tickLower, _tickUpper, liquidity, amount0Max, amount1Max, recipient, hookData);
+        params[1] = abi.encode(poolKey.currency0, poolKey.currency1);
+        return (actions, params);
+    }
+}

--- a/src/PoolDeployer.sol
+++ b/src/PoolDeployer.sol
@@ -10,7 +10,6 @@ import {Actions} from "v4-periphery/src/libraries/Actions.sol";
 import {LiquidityAmounts} from "v4-core/test/utils/LiquidityAmounts.sol";
 import {TickMath} from "v4-core/src/libraries/TickMath.sol";
 import {IERC20} from "forge-std/interfaces/IERC20.sol";
-//import {IAllowanceTransfer} from "permit2/src/interfaces/IAllowanceTransfer.sol";
 
 interface IAllowanceTransfer {
     function approve(

--- a/src/PoolDeployer.sol
+++ b/src/PoolDeployer.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import "forge-std/console.sol";
 import {PositionManager} from "v4-periphery/src/PositionManager.sol";
 import {IHooks} from "v4-core/src/interfaces/IHooks.sol";
 import {PoolKey} from "v4-core/src/types/PoolKey.sol";
@@ -32,11 +33,13 @@ contract PoolDeployer {
 
     PositionManager public posm;
     IERC20 public token;
-    address public hookAddress = address(0x45A0AA93f6972AA137086002527B2ECc1D1b8844);
+    // FIXME don't hardcode
+    address public hookAddress = address(0x3AA84C1124d83be2BdD5ab193E3F0A84946A8844);
 
     // the startingPrice is expressed as sqrtPriceX96: floor(sqrt(token / token0) * 2^96)
     // use 1000:1 as starting price based on jb price of 0.001 per token
-    uint160 public startingPrice = 2505414483750479251915866636288;
+    //uint160 public startingPrice = 2505414483750479251915866636288;
+    uint160 startingPrice = 79228162514264337593543950336; // floor(sqrt(1) * 2^96)
     int24  public tickLower     = -600;
     int24  public tickUpper     =  600;
 
@@ -62,9 +65,10 @@ contract PoolDeployer {
     }
 
     function createAndAddLiquidity() external {
-        uint256 amount0 = address(this).balance;
-        uint256 amount1 = token.balanceOf(address(this));
+        uint256 amount0 = address(this).balance - 1 wei;
+        uint256 amount1 = token.balanceOf(address(this)) - 1 wei;
         require(amount0 > 0 && amount1 > 0, "no funds to deploy");
+        console.log("amount0: %s, amount1: %s", amount0, amount1);
 
         // approvals for PERMIT2 & PositionManager
         token.approve(address(PERMIT2), type(uint256).max);
@@ -78,8 +82,8 @@ contract PoolDeployer {
             amount1
         );
 
-        uint256 amount0Max = amount0;
-        uint256 amount1Max = amount1;
+        uint256 amount0Max = amount0 + 1 wei;
+        uint256 amount1Max = amount1 + 1 wei;
 
 
         int24 tickSpacing = 60;

--- a/test/MissionTest.t.sol
+++ b/test/MissionTest.t.sol
@@ -6,6 +6,7 @@ import "forge-std/console.sol";
 import "forge-std/Test.sol";
 import {Vesting} from "../src/Vesting.sol";
 import {PoolDeployer} from "../src/PoolDeployer.sol";
+import "@nana-core/interfaces/IJBRulesetApprovalHook.sol";
 import {IJBRulesets} from "@nana-core/interfaces/IJBRulesets.sol";
 import {IJBMultiTerminal} from "@nana-core/interfaces/IJBMultiTerminal.sol";
 import {IJBDirectory} from "@nana-core/interfaces/IJBDirectory.sol";
@@ -338,7 +339,6 @@ contract MissionTest is Test {
 
     function testCreateTeamProjectCashoutMultipleContributors() public {
         vm.startPrank(user1);
-        uint256 deadline = block.timestamp + 2 days;
         moonDAOTeamCreator.createMoonDAOTeam{value: 0.555 ether}("", "", "","name", "bio", "image", "twitter", "communications", "website", "view", "formId", new address[](0));
         uint256 missionId = missionCreator.createMission(
            0,
@@ -401,7 +401,6 @@ contract MissionTest is Test {
             0,
             payable(user1),
             bytes(""));
-        console.log("user1CashOutAmount", user1CashOutAmount);
         uint256 user1BalanceAfter = address(user1).balance;
         assertEq(user1CashOutAmount, payAmount);
         assertEq(user1BalanceAfter - user1BalanceBefore, payAmount);
@@ -426,7 +425,6 @@ contract MissionTest is Test {
 
     function testCreateTeamProjectCashoutEarly() public {
         vm.startPrank(user1);
-        uint256 deadline = block.timestamp + 2 days;
         moonDAOTeamCreator.createMoonDAOTeam{value: 0.555 ether}("", "", "","name", "bio", "image", "twitter", "communications", "website", "view", "formId", new address[](0));
         uint256 missionId = missionCreator.createMission(
            0,
@@ -473,7 +471,6 @@ contract MissionTest is Test {
 
     function testCreateTeamProjectCashoutCashoutAfterMinFundingMet() public {
         vm.startPrank(user1);
-        uint256 deadline = block.timestamp + 2 days;
         moonDAOTeamCreator.createMoonDAOTeam{value: 0.555 ether}("", "", "","name", "bio", "image", "twitter", "communications", "website", "view", "formId", new address[](0));
         uint256 missionId = missionCreator.createMission(
            0,
@@ -521,7 +518,6 @@ contract MissionTest is Test {
 
     function testCreateTeamProjectVestTokens() public {
         vm.startPrank(user1);
-        uint256 deadline = block.timestamp + 2 days;
         moonDAOTeamCreator.createMoonDAOTeam{value: 0.555 ether}("", "", "","name", "bio", "image", "twitter", "communications", "website", "view", "formId", new address[](0));
         uint256 missionId = missionCreator.createMission(
            0,
@@ -564,7 +560,7 @@ contract MissionTest is Test {
         uint256 tokensTeamVesting = jbTokens.totalBalanceOf(address(teamVesting), projectId);
         uint256 tokensMoonDAOVesting = jbTokens.totalBalanceOf(address(moonDAOVesting), projectId);
         assertEq(tokensTeamVesting, 300 * 1e18);
-        assertEq(tokensMoonDAOVesting, 100 * 1e18);
+        assertEq(tokensMoonDAOVesting, 150 * 1e18);
         assertEq(jbTokens.totalBalanceOf(TREASURY, projectId), 0);
         assertEq(jbTokens.totalBalanceOf(teamAddress, projectId), 0);
 
@@ -573,26 +569,25 @@ contract MissionTest is Test {
         assertEq(moonDAOVesting.vestedAmount(), 0);
         skip(165 days);
         assertEq(teamVesting.vestedAmount(), 300/4 * 1e18);
-        assertEq(moonDAOVesting.vestedAmount(), 100/4 * 1e18);
+        assertEq(moonDAOVesting.vestedAmount(), 150/4 * 1e18);
 
         vm.startPrank(TREASURY);
         moonDAOVesting.withdraw();
         vm.stopPrank();
-        assertEq(jbTokens.totalBalanceOf(TREASURY, projectId), 100/4 * 1e18);
+        assertEq(jbTokens.totalBalanceOf(TREASURY, projectId), 150/4 * 1e18);
 
         skip(365 days);
         assertEq(teamVesting.vestedAmount(), 300/2 * 1e18);
-        assertEq(moonDAOVesting.vestedAmount(), 100/2 * 1e18);
+        assertEq(moonDAOVesting.vestedAmount(), 150/2 * 1e18);
 
         vm.startPrank(TREASURY);
         moonDAOVesting.withdraw();
         vm.stopPrank();
-        assertEq(jbTokens.totalBalanceOf(TREASURY, projectId), 100/2 * 1e18);
+        assertEq(jbTokens.totalBalanceOf(TREASURY, projectId), 150/2 * 1e18);
     }
 
     function testCreateTeamProjectPayouts() public {
         vm.startPrank(user1);
-        uint256 deadline = block.timestamp + 2 days;
         moonDAOTeamCreator.createMoonDAOTeam{value: 0.555 ether}("", "", "","name", "bio", "image", "twitter", "communications", "website", "view", "formId", new address[](0));
         uint256 missionId = missionCreator.createMission(
            0,
@@ -611,8 +606,8 @@ contract MissionTest is Test {
         uint256 balance = jbTerminalStore.balanceOf(address(terminal), projectId, JBConstants.NATIVE_TOKEN);
         assertEq(balance, 0);
 
-        // Lower payment that numbers work out nice, 500 contributor tokens, and 500 reserved tokens.
-        uint256 payAmount = 500_000_000_000_000_000;
+        // Pay enough to pass goal and skip to deadline
+        uint256 payAmount = 10_000_000_000_000_000_000;
         terminal.pay{value: payAmount}(
             projectId,
             JBConstants.NATIVE_TOKEN,
@@ -622,6 +617,8 @@ contract MissionTest is Test {
             "",
             new bytes(0)
         );
+        skip(28 days);
+
         uint256 terminalBalance = jbTerminalStore.balanceOf(address(terminal), projectId, JBConstants.NATIVE_TOKEN);
         uint256 treasuryBalanceBefore = address(TREASURY).balance;
         uint256 teamBalanceBefore = address(teamAddress).balance;
@@ -642,14 +639,13 @@ contract MissionTest is Test {
 
     function testCreateTeamProjectAMM() public {
         vm.startPrank(user1);
-        uint256 deadline = block.timestamp + 2 days;
         moonDAOTeamCreator.createMoonDAOTeam{value: 0.555 ether}("", "", "","name", "bio", "image", "twitter", "communications", "website", "view", "formId", new address[](0));
         uint256 missionId = missionCreator.createMission(
            0,
            teamAddress,
            "",
            10_000_000_000_000_000_000,
-           deadline,
+           block.timestamp + 28 days,
            true,
            "TEST TOKEN",
            "TEST",
@@ -661,8 +657,8 @@ contract MissionTest is Test {
         uint256 balance = jbTerminalStore.balanceOf(address(terminal), projectId, JBConstants.NATIVE_TOKEN);
         assertEq(balance, 0);
 
-        // Lower payment that numbers work out nice, 500 contributor tokens, and 500 reserved tokens.
-        uint256 payAmount = 500_000_000_000_000_000;
+        // Pay enough to pass goal and skip to deadline
+        uint256 payAmount = 10_000_000_000_000_000_000;
         terminal.pay{value: payAmount}(
             projectId,
             JBConstants.NATIVE_TOKEN,
@@ -672,6 +668,7 @@ contract MissionTest is Test {
             "",
             new bytes(0)
         );
+        skip(28 days);
         uint256 terminalBalance = jbTerminalStore.balanceOf(address(terminal), projectId, JBConstants.NATIVE_TOKEN);
         jbController.sendReservedTokensToSplitsOf(projectId);
         uint256 payoutAmount = IJBMultiTerminal(address(terminal)).sendPayoutsOf(
@@ -684,7 +681,7 @@ contract MissionTest is Test {
 
         PoolDeployer poolDeployer = PoolDeployer(payable(missionCreator.missionIdToPoolDeployer(missionId)));
         uint256 tokensPoolDeployer = jbTokens.totalBalanceOf(address(poolDeployer), projectId);
-        assertEq(tokensPoolDeployer, 100 * 1e18);
+        assertEq(tokensPoolDeployer, 1_000 * 1e18);
         // JB splits have 7 decimals of precision, so check up to 6 decimals
         assertApproxEqRel(address(poolDeployer).balance, terminalBalance / 10, 0.0000001e18);
         poolDeployer.createAndAddLiquidity();

--- a/test/MissionTest.t.sol
+++ b/test/MissionTest.t.sol
@@ -621,26 +621,72 @@ contract MissionTest is Test {
             "",
             new bytes(0)
         );
-        uint256 balanceAfter1 = jbTerminalStore.balanceOf(address(terminal), projectId, JBConstants.NATIVE_TOKEN);
-        assertEq(balanceAfter1, payAmount);
-        uint256 tokensAfter1 = jbTokens.totalBalanceOf(user1, projectId);
-        assertEq(tokensAfter1, 500 * 1e18);
-
-        // FIXME this needs to be called once the token is launched
-        jbController.sendReservedTokensToSplitsOf(projectId);
-        address tokenAddress = address(jbTokens.tokenOf(projectId));
-        //uint256 JB_ETH_CURRENCY = 1;
+        uint256 terminalBalance = jbTerminalStore.balanceOf(address(terminal), projectId, JBConstants.NATIVE_TOKEN);
+        uint256 treasuryBalanceBefore = address(TREASURY).balance;
+        uint256 teamBalanceBefore = address(teamAddress).balance;
         uint256 payoutAmount = IJBMultiTerminal(address(terminal)).sendPayoutsOf(
             projectId,
             JBConstants.NATIVE_TOKEN,
-            1,
+            terminalBalance,
             uint32(uint160(JBConstants.NATIVE_TOKEN)),
             0
         );
-        console.log("payoutAmount", payoutAmount);
 
         PoolDeployer poolDeployer = PoolDeployer(payable(missionCreator.missionIdToPoolDeployer(missionId)));
-        assertEq(jbTokens.totalBalanceOf(address(poolDeployer), projectId), 100 * 1e18);
+        // JB splits have 7 decimals of precision, so check up to 6 decimals
+        assertApproxEqRel(address(poolDeployer).balance, terminalBalance / 10, 0.0000001e18);
+        assertApproxEqRel(address(TREASURY).balance - treasuryBalanceBefore, terminalBalance * 75/ 1000, 0.0000001e18);
+        assertApproxEqRel(teamAddress.balance - teamBalanceBefore, terminalBalance *80 / 100, 0.0000001e18);
+    }
+
+    function testCreateTeamProjectAMM() public {
+        vm.startPrank(user1);
+        uint256 deadline = block.timestamp + 2 days;
+        moonDAOTeamCreator.createMoonDAOTeam{value: 0.555 ether}("", "", "","name", "bio", "image", "twitter", "communications", "website", "view", "formId", new address[](0));
+        uint256 missionId = missionCreator.createMission(
+           0,
+           teamAddress,
+           "",
+           10_000_000_000_000_000_000,
+           deadline,
+           true,
+           "TEST TOKEN",
+           "TEST",
+           "This is a test project"
+        );
+        uint256 projectId = missionCreator.missionIdToProjectId(missionId);
+
+        IJBTerminal terminal = jbDirectory.primaryTerminalOf(projectId, JBConstants.NATIVE_TOKEN);
+        uint256 balance = jbTerminalStore.balanceOf(address(terminal), projectId, JBConstants.NATIVE_TOKEN);
+        assertEq(balance, 0);
+
+        // Lower payment that numbers work out nice, 500 contributor tokens, and 500 reserved tokens.
+        uint256 payAmount = 500_000_000_000_000_000;
+        terminal.pay{value: payAmount}(
+            projectId,
+            JBConstants.NATIVE_TOKEN,
+            0,
+            user1,
+            0,
+            "",
+            new bytes(0)
+        );
+        uint256 terminalBalance = jbTerminalStore.balanceOf(address(terminal), projectId, JBConstants.NATIVE_TOKEN);
+        jbController.sendReservedTokensToSplitsOf(projectId);
+        uint256 payoutAmount = IJBMultiTerminal(address(terminal)).sendPayoutsOf(
+            projectId,
+            JBConstants.NATIVE_TOKEN,
+            terminalBalance,
+            uint32(uint160(JBConstants.NATIVE_TOKEN)),
+            0
+        );
+
+        PoolDeployer poolDeployer = PoolDeployer(payable(missionCreator.missionIdToPoolDeployer(missionId)));
+        uint256 tokensPoolDeployer = jbTokens.totalBalanceOf(address(poolDeployer), projectId);
+        assertEq(tokensPoolDeployer, 100 * 1e18);
+        // JB splits have 7 decimals of precision, so check up to 6 decimals
+        assertApproxEqRel(address(poolDeployer).balance, terminalBalance / 10, 0.0000001e18);
+        poolDeployer.createAndAddLiquidity();
     }
 
     function testSetJBController() public {

--- a/test/MissionTest.t.sol
+++ b/test/MissionTest.t.sol
@@ -53,6 +53,7 @@ contract MissionTest is Test {
 
     function setUp() public {
         vm.deal(user1, 100 ether);
+        vm.deal(user2, 100 ether);
 
         vm.startPrank(user1);
 
@@ -106,7 +107,7 @@ contract MissionTest is Test {
            teamAddress,
            "",
            10_000_000_000_000_000_000,
-           0,
+           block.timestamp + 28 days,
            true,
            "TEST TOKEN",
            "TEST",
@@ -146,7 +147,7 @@ contract MissionTest is Test {
            teamAddress,
            "",
            0,
-           0,
+           block.timestamp + 28 days,
            true,
            "TEST TOKEN",
            "TEST",
@@ -184,7 +185,7 @@ contract MissionTest is Test {
            user1,
            "",
            10_000_000_000_000_000_000,
-           0,
+           block.timestamp + 28 days,
            true,
            "TEST TOKEN",
            "TEST",
@@ -218,7 +219,7 @@ contract MissionTest is Test {
            teamAddress,
            "",
            10_000_000_000_000_000_000,
-           0,
+           block.timestamp + 28 days,
            true,
            "TEST TOKEN",
            "TEST",
@@ -254,7 +255,7 @@ contract MissionTest is Test {
            teamAddress,
            "",
            10_000_000_000_000_000_000,
-           0,
+           block.timestamp + 28 days,
            true,
            "TEST TOKEN",
            "TEST",
@@ -285,14 +286,13 @@ contract MissionTest is Test {
 
     function testCreateTeamProjectCashout() public {
         vm.startPrank(user1);
-        uint256 deadline = block.timestamp + 2 days;
         moonDAOTeamCreator.createMoonDAOTeam{value: 0.555 ether}("", "", "","name", "bio", "image", "twitter", "communications", "website", "view", "formId", new address[](0));
         uint256 missionId = missionCreator.createMission(
            0,
            teamAddress,
            "",
            10_000_000_000_000_000_000,
-           0,
+           block.timestamp + 28 days,
            true,
            "TEST TOKEN",
            "TEST",
@@ -345,7 +345,7 @@ contract MissionTest is Test {
            teamAddress,
            "",
            10_000_000_000_000_000_000,
-           0,
+           block.timestamp + 28 days,
            true,
            "TEST TOKEN",
            "TEST",
@@ -401,6 +401,7 @@ contract MissionTest is Test {
             0,
             payable(user1),
             bytes(""));
+        console.log("user1CashOutAmount", user1CashOutAmount);
         uint256 user1BalanceAfter = address(user1).balance;
         assertEq(user1CashOutAmount, payAmount);
         assertEq(user1BalanceAfter - user1BalanceBefore, payAmount);
@@ -432,7 +433,7 @@ contract MissionTest is Test {
            teamAddress,
            "",
            10_000_000_000_000_000_000,
-           0,
+           block.timestamp + 28 days,
            true,
            "TEST TOKEN",
            "TEST",
@@ -479,7 +480,7 @@ contract MissionTest is Test {
            teamAddress,
            "",
            10_000_000_000_000_000_000,
-           0,
+           block.timestamp + 28 days,
            true,
            "TEST TOKEN",
            "TEST",
@@ -527,7 +528,7 @@ contract MissionTest is Test {
            teamAddress,
            "",
            10_000_000_000_000_000_000,
-           0,
+           block.timestamp + 28 days,
            true,
            "TEST TOKEN",
            "TEST",
@@ -598,7 +599,7 @@ contract MissionTest is Test {
            teamAddress,
            "",
            10_000_000_000_000_000_000,
-           0,
+           block.timestamp + 28 days,
            true,
            "TEST TOKEN",
            "TEST",

--- a/test/MissionTest.t.sol
+++ b/test/MissionTest.t.sol
@@ -2,8 +2,10 @@
 
 pragma solidity ^0.8.20;
 
+import "forge-std/console.sol";
 import "forge-std/Test.sol";
 import {Vesting} from "../src/Vesting.sol";
+import {PoolDeployer} from "../src/PoolDeployer.sol";
 import {IJBRulesets} from "@nana-core/interfaces/IJBRulesets.sol";
 import {IJBMultiTerminal} from "@nana-core/interfaces/IJBMultiTerminal.sol";
 import {IJBDirectory} from "@nana-core/interfaces/IJBDirectory.sol";
@@ -32,8 +34,7 @@ contract MissionTest is Test {
     address user1 = address(0x1);
     address teamAddress = address(0x2);
     address user2 = address(0x3);
-    address user4 = address(0x4);
-    address TREASURY = user4;
+    address TREASURY = address(0x4);
 
     bytes32 internal constant SALT = bytes32(abi.encode(0x4a75));
 
@@ -586,6 +587,60 @@ contract MissionTest is Test {
         moonDAOVesting.withdraw();
         vm.stopPrank();
         assertEq(jbTokens.totalBalanceOf(TREASURY, projectId), 100/2 * 1e18);
+    }
+
+    function testCreateTeamProjectPayouts() public {
+        vm.startPrank(user1);
+        uint256 deadline = block.timestamp + 2 days;
+        moonDAOTeamCreator.createMoonDAOTeam{value: 0.555 ether}("", "", "","name", "bio", "image", "twitter", "communications", "website", "view", "formId", new address[](0));
+        uint256 missionId = missionCreator.createMission(
+           0,
+           teamAddress,
+           "",
+           10_000_000_000_000_000_000,
+           0,
+           true,
+           "TEST TOKEN",
+           "TEST",
+           "This is a test project"
+        );
+        uint256 projectId = missionCreator.missionIdToProjectId(missionId);
+
+        IJBTerminal terminal = jbDirectory.primaryTerminalOf(projectId, JBConstants.NATIVE_TOKEN);
+        uint256 balance = jbTerminalStore.balanceOf(address(terminal), projectId, JBConstants.NATIVE_TOKEN);
+        assertEq(balance, 0);
+
+        // Lower payment that numbers work out nice, 500 contributor tokens, and 500 reserved tokens.
+        uint256 payAmount = 500_000_000_000_000_000;
+        terminal.pay{value: payAmount}(
+            projectId,
+            JBConstants.NATIVE_TOKEN,
+            0,
+            user1,
+            0,
+            "",
+            new bytes(0)
+        );
+        uint256 balanceAfter1 = jbTerminalStore.balanceOf(address(terminal), projectId, JBConstants.NATIVE_TOKEN);
+        assertEq(balanceAfter1, payAmount);
+        uint256 tokensAfter1 = jbTokens.totalBalanceOf(user1, projectId);
+        assertEq(tokensAfter1, 500 * 1e18);
+
+        // FIXME this needs to be called once the token is launched
+        jbController.sendReservedTokensToSplitsOf(projectId);
+        address tokenAddress = address(jbTokens.tokenOf(projectId));
+        //uint256 JB_ETH_CURRENCY = 1;
+        uint256 payoutAmount = IJBMultiTerminal(address(terminal)).sendPayoutsOf(
+            projectId,
+            JBConstants.NATIVE_TOKEN,
+            1,
+            uint32(uint160(JBConstants.NATIVE_TOKEN)),
+            0
+        );
+        console.log("payoutAmount", payoutAmount);
+
+        PoolDeployer poolDeployer = PoolDeployer(payable(missionCreator.missionIdToPoolDeployer(missionId)));
+        assertEq(jbTokens.totalBalanceOf(address(poolDeployer), projectId), 100 * 1e18);
     }
 
     function testSetJBController() public {


### PR DESCRIPTION
Switches from a single ruleset to two:

        - Ruleset 0 is funding/refunds
        - Ruleset 0 has a cashout hook that enables refunds if the deadline has passed and the funding goal has not been met.
        - Ruleset 0 has an approval hook that will automatically move to ruleset 1 if the funding goal is met and if the deadline has passed.
        - Ruleset 1 enables ETH payouts
        - Ruleset 0/1 only differ in approval hook and fund access limits


Adds LaunchPadApprovalHook which will unlock payouts once the funding goal is reached and deadline is passed.
Adds PoolDeployer to launch AMM after payouts are sent.
Account for 2.5% JB fee in ETH splits.